### PR TITLE
Automatically add keys to keys.py, increment frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Then you can run tx_helium.py to send messages by specifying the msg and the fra
 
     python3 tx_helium.py --msg "Test" --frame 1
 
+If you leave out the arguments, "Test" will be used for the frame. If you initialized with `otaa_helium.py` a file called `.last_frame` will be created and set to `0`. `tx_helium.py` will automatically increment. If the frame count is off simply edit `.last_frame` to the last frame number recieved by Helium, or run `otaa_helium.py` again
+
 You can run rssi_helium.py which utilizes the OLED screen and buttons.
 
 This will sent a tranmission when it starts and whenever you press the middle button.
@@ -35,6 +37,6 @@ The script pulls the RSSI, the packet RSSI, and the SNR and displays it on the O
 
 ![alt text][pi]
 
-## TODO
-Automatically track frame number. 
-Automatically capture device registration info and put in keys.py.
+##TODO
+Automatically call otaa_helium if `.last_frame` is missing
+

--- a/otaa_helium.py
+++ b/otaa_helium.py
@@ -10,10 +10,11 @@ from random import randrange
 import reset_ada
 import helium
 import keys
-
+from os import rename
 BOARD.setup()
 parser = LoRaArgumentParser("LoRaWAN sender")
 class LoRaWANotaa(LoRa):
+    keys_written = False
     def __init__(self, verbose = False):
         super(LoRaWANotaa, self).__init__(verbose)
 
@@ -38,6 +39,23 @@ class LoRaWANotaa(LoRa):
             print("nwskey = {}".format(lorawan.derive_nwskey(devnonce)))
             print("appskey = {}".format(lorawan.derive_appskey(devnonce)))
             print("\n")
+            if not self.keys_written:
+                old_keys = open('keys.py', 'r')
+                new_keys = open('keys2.py', 'w')
+                for line in old_keys:
+                    if line.split(' ')[0] in ['deveui', 'appeui', 'appkey']:
+                        new_keys.write(line)
+                new_keys.write("devaddr = {}\n".format(lorawan.get_devaddr()))
+                new_keys.write("nwskey = {}\n".format(lorawan.derive_nwskey(devnonce)))
+                new_keys.write("appskey = {}\n".format(lorawan.derive_appskey(devnonce)))
+                self.keys_written = True;
+                new_keys.close()
+                old_keys.close()
+                rename('keys2.py', 'keys.py')
+                with open('.last_frame', 'w') as f:
+                    f.write("0")
+                print("Reset frame counter to 0")
+
             sys.exit(0)
 
         print("Got LoRaWAN message continue listen for join accept")

--- a/tx_helium.py
+++ b/tx_helium.py
@@ -66,7 +66,10 @@ class LoRaWANotaa(LoRa):
         self.set_bw(9) #500Khz
         self.set_rx_crc(False)#TRUE
         self.set_mode(MODE.RXCONT)
-        
+        with open('.last_frame', 'w') as f:
+            f.write(str(frame))
+         
+
 
     def start(self):
         global frame
@@ -119,8 +122,15 @@ def main():
     parser.add_argument("--frame", help="Message frame")
     parser.add_argument("--msg", help="tokens file")
     args = parser.parse_args()
-    frame = int(args.frame)
-    msg = args.msg
+    if args.frame is None:
+        with open(".last_frame", 'r') as last_frame_file:
+            frame = int(last_frame_file.read()) + 1
+    else:
+        frame = int(args.frame)
+    if args.msg is None:
+        msg = "Test"
+    else:
+        msg = args.msg
     init()
 
 if __name__ == "__main__":


### PR DESCRIPTION
I did a hacky method to automatically increment. keys.py is read into memory, the 3 OTAA keys are copied and written to a temp file `keys2.py`, and the ABP keys are written to it and the files are closed. It creates a file called `.last_frame` to increment the frame which `tx_helium.py` looks for if the `--frame` argument is not specified. If both `--frame` is not specified and `.last_backup` is not present it will crash. Ideally it will re-register with `otaa_helium.py`  but I didn't have time to refactor it to make it importable
